### PR TITLE
general clean up and add cmake files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,58 @@
+# Check the cmake version and name the project
+cmake_minimum_required(VERSION 3.2.0)
+
+# This is not a conventional top-level cmake file. Rather it is a
+# placeholder that has simple constructs for the settings needed to to
+# build against external hdf5, eigen, and gtest libraries.  This is
+# very minimal and does not have elegant cmake find logic. I use
+# find_package Eigen and HDF5 as this seems to work for my windows and
+# ubuntu configurations. But gtest is more difficult.
+# 
+# The recommended gtest convention is to include the gtest fused
+# source along with the source of the project being tested. I do not
+# want to make such a major addition to eigen3-hdf5, so this is the
+# best I could come up with for now.  I require the cmake configure
+# invocation to set locations explicitly for gtest include and
+# libraries. Here is an example invocation that I used to test on
+# linux
+#
+# cmake -DCMAKE_PREFIX_PATH=/opt/pkg/eigen \
+#       -Dgtest_INCLUDE_DIR=/opt/pkg/gtest/include_fused \
+#       -Dgtest_LIBRARIES=/opt/pkg/gtest/build/libgtest_main.a;/opt/pkg/gtest/build/libgtest.a
+#       ..
+#
+# In addition to having the required find_package logic, conventional
+# top-level cmake files will also have install logic and should
+# generate some documentation. Neither of these are part of
+# eigen3-hdf5, so they are not here yet.
+
+set(CMAKE_DEBUG_POSTFIX d)
+
+project(eigen3-hdf5)
+
+# Eigen
+find_package(Eigen REQUIRED)
+message (STATUS "eigen_INCLUDE_DIRS=${eigen_INCLUDE_DIRS}")
+include_directories(${eigen_INCLUDE_DIRS})
+
+# gtest use -Dgtest_INCLUDE_DIR=... -Dgtest_LIBRARIES=... when
+# configuring cmake
+
+# HDF5
+
+# look for an hdf5 cmake config file
+find_package(HDF5 NO_MODULE QUIET COMPONENTS CXX HL)
+
+if (NOT HDF5_FOUND)
+  # config file not found, so try to find using a module
+  find_package(HDF5 REQUIRED MODULE COMPONENTS CXX HL)
+  if ("${HDF5_EXPORT_LIBRARIES}" STREQUAL "")
+    # set this config variable using the module variable to simplify
+    # the target_link_libraries statement
+    set(HDF5_EXPORT_LIBRARIES ${HDF5_LIBRARIES})
+  endif()
+endif()
+
+enable_testing()
+
+add_subdirectory(unittests)

--- a/eigen3-hdf5.hpp
+++ b/eigen3-hdf5.hpp
@@ -271,7 +271,6 @@ namespace internal
             return false;
         }
 
-        bool written = false;
         typename Derived::Index rows = mat.rows();
         typename Derived::Index cols = mat.cols();
         typename Derived::Index stride = mat.derived().outerStride();
@@ -451,10 +450,13 @@ namespace internal
         Eigen::DenseBase<Derived> &mat_ = const_cast<Eigen::DenseBase<Derived> &>(mat);
         mat_.derived().resize(rows, cols);
         bool written = false;
-        if (mat.Flags & Eigen::RowMajor || dimensions[0] == 1 || dimensions[1] == 1)
+        bool isRowMajor = mat.Flags & Eigen::RowMajor;
+        if (isRowMajor || dimensions[0] == 1 || dimensions[1] == 1)
         {
             // mat is already row major
-            typename Derived::Index stride = mat_.derived().outerStride();
+            typename Derived::Index istride = mat_.derived().outerStride();
+            assert(istride >= 0);
+            hsize_t stride = istride >= 0 ? istride : 0;
             if (stride == cols || (stride == rows && cols == 1))
             {
                 // mat has natural stride, so read directly into its data block

--- a/eigen3-hdf5.hpp
+++ b/eigen3-hdf5.hpp
@@ -231,9 +231,15 @@ namespace internal
             return false;
         }
 
-        typename Derived::Index rows = mat.rows();
-        typename Derived::Index cols = mat.cols();
-        typename Derived::Index mat_stride = mat.derived().outerStride();
+        typename Derived::Index irows = mat.rows();
+        typename Derived::Index icols = mat.cols();
+        typename Derived::Index imat_stride = mat.derived().outerStride();
+        assert(irows >= 0);
+        assert(icols >= 0);
+        assert(imat_stride >= 0);
+        hsize_t rows = irows >= 0 ? irows : 0;
+        hsize_t cols = icols >= 0 ? icols : 0;
+        hsize_t mat_stride = imat_stride >= 0 ? imat_stride : 0;
 
         // slab params for the file data
         hsize_t fstride[2] = { 1, cols };
@@ -271,9 +277,15 @@ namespace internal
             return false;
         }
 
-        typename Derived::Index rows = mat.rows();
-        typename Derived::Index cols = mat.cols();
-        typename Derived::Index stride = mat.derived().outerStride();
+        typename Derived::Index irows = mat.rows();
+        typename Derived::Index icols = mat.cols();
+        typename Derived::Index istride = mat.derived().outerStride();
+        assert(irows >= 0);
+        assert(icols >= 0);
+        assert(istride >= 0);
+        hsize_t rows = irows >= 0 ? irows : 0;
+        hsize_t cols = icols >= 0 ? icols : 0;
+        hsize_t stride = istride >= 0 ? istride : 0;
 
         // slab params for the file data
         hsize_t fstride[2] = { 1, cols };
@@ -291,7 +303,7 @@ namespace internal
 
         // transpose the column major data in memory to the row major data in the file by
         // writing one row slab at a time. 
-        for (int i = 0; i < rows; i++)
+        for (hsize_t i = 0; i < rows; i++)
         {
             hsize_t fstart[2] = { i, 0 };
             hsize_t mstart[2] = { 0, i };
@@ -376,12 +388,28 @@ namespace internal
         dataset.read(datatype, data);
     }
     
+    // read a column major attribute; I do not know if there is an hdf routine to read an
+    // attribute hyperslab, so I take the lazy way out: just read the conventional hdf
+    // row major data and let eigen copy it into mat. 
     template <typename Derived>
-    bool read_colmat(Eigen::EigenBase<Derived>* mat,
+    bool read_colmat(const Eigen::DenseBase<Derived> &mat,
+        const H5::DataType * const datatype,
+        const H5::Attribute &dataset)
+    {
+        typename Derived::Index rows = mat.rows();
+        typename Derived::Index cols = mat.cols();
+        typename Eigen::Matrix<typename Derived::Scalar, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor> temp(rows, cols);
+        internal::read_data(dataset, temp.data(), *datatype);
+        const_cast<Eigen::DenseBase<Derived> &>(mat) = temp;
+        return true;
+    }
+
+    template <typename Derived>
+    bool read_colmat(const Eigen::DenseBase<Derived> &mat,
         const H5::DataType * const datatype,
         const H5::DataSet &dataset)
     {
-        if (mat->derived().innerStride() != 1)
+        if (mat.derived().innerStride() != 1)
         {
             // inner stride != 1 is an edge case this function does not (yet) handle. (I think it
             // could by using the inner stride as the first element of mstride below. But I do
@@ -389,15 +417,21 @@ namespace internal
             return false;
         }
 
-        typename Derived::Index rows = mat->rows();
-        typename Derived::Index cols = mat->cols();
-        typename Derived::Index stride = mat->derived().outerStride();
-        if (stride != rows)
+        typename Derived::Index irows = mat.rows();
+        typename Derived::Index icols = mat.cols();
+        typename Derived::Index istride = mat.derived().outerStride();
+        if (istride != irows)
         {
             // this function does not (yet) read into a mat that has a different stride than the
             // dataset. 
             return false;
         }
+        assert(irows >= 0);
+        assert(icols >= 0);
+        assert(istride >= 0);
+        hsize_t rows = irows >= 0 ? irows : 0;
+        hsize_t cols = icols >= 0 ? icols : 0;
+        hsize_t stride = istride >= 0 ? istride : 0;
 
 
         // slab params for the file data
@@ -420,13 +454,13 @@ namespace internal
 
         // transpose the column major data in memory to the row major data in the file by
         // writing one row slab at a time. 
-        for (int i = 0; i < rows; i++)
+        for (hsize_t i = 0; i < rows; i++)
         {
             hsize_t fstart[2] = { i, 0 };
             hsize_t mstart[2] = { 0, i };
             fspace.selectHyperslab(H5S_SELECT_SET, fcount, fstart, fstride, fblock);
             mspace.selectHyperslab(H5S_SELECT_SET, mcount, mstart, mstride, mblock);
-            dataset.read(mat->derived().data(), *datatype, mspace, fspace);
+            dataset.read(const_cast<Eigen::DenseBase<Derived> &>(mat).derived().data(), *datatype, mspace, fspace);
         }
         return true;
     }
@@ -469,7 +503,7 @@ namespace internal
             // colmajor flag is 0 so the assert needs to check that mat is not rowmajor. 
             assert(!(mat.Flags & Eigen::RowMajor));
 
-            //written = read_colmat(&mat_, datatype, dataset);
+            written = read_colmat(mat_, datatype, dataset);
         }
 
         if (!written)

--- a/unittests/CMakeLists.txt
+++ b/unittests/CMakeLists.txt
@@ -1,6 +1,8 @@
 project(eigen3-hdf5-tests)
 
 include_directories(..)
+include_directories(${HDF5_CXX_INCLUDE_DIR})
+include_directories(${gtest_INCLUDE_DIR})
 
 set(${PROJECT_NAME}_SOURCES
     test_Attribute.cpp
@@ -18,7 +20,12 @@ endif()
 
 add_executable(${PROJECT_NAME} ${${PROJECT_NAME}_SOURCES})
 
-target_link_libraries(${PROJECT_NAME} GTest GTestMain)
+if (DEFINED gtest_LIBRARIES)
+  target_link_libraries(${PROJECT_NAME} ${gtest_LIBRARIES})
+else()
+  target_link_libraries(${PROJECT_NAME} GTest GTestMain)
+endif()
+
 target_link_libraries(${PROJECT_NAME} ${HDF5_EXPORT_LIBRARIES})
 
 add_test(NAME ${PROJECT_NAME} COMMAND ${PROJECT_NAME} WORKING_DIRECTORY ${CMAKE_BINARY_DIR})

--- a/unittests/CMakeLists.txt
+++ b/unittests/CMakeLists.txt
@@ -9,6 +9,11 @@ set(${PROJECT_NAME}_SOURCES
     test_VectorRoundTrip.cpp
     )
 
+if (WIN32)
+    add_definitions(/W4 /wd4251)
+else()
+endif()
+
 add_executable(${PROJECT_NAME} ${${PROJECT_NAME}_SOURCES})
 
 target_link_libraries(${PROJECT_NAME} hdf5 hdf5_cpp GTest GTestMain)

--- a/unittests/CMakeLists.txt
+++ b/unittests/CMakeLists.txt
@@ -1,0 +1,14 @@
+project(eigen3-hdf5-tests)
+
+include_directories(..)
+
+set(${PROJECT_NAME}_SOURCES
+    test_Attribute.cpp
+    test_MatrixRoundTrip.cpp
+    test_Sparse.cpp
+    test_VectorRoundTrip.cpp
+    )
+
+add_executable(${PROJECT_NAME} ${${PROJECT_NAME}_SOURCES})
+
+target_link_libraries(${PROJECT_NAME} hdf5 hdf5_cpp GTest GTestMain)

--- a/unittests/CMakeLists.txt
+++ b/unittests/CMakeLists.txt
@@ -7,13 +7,18 @@ set(${PROJECT_NAME}_SOURCES
     test_MatrixRoundTrip.cpp
     test_Sparse.cpp
     test_VectorRoundTrip.cpp
+    gtest-helpers.hpp
     )
 
 if (WIN32)
     add_definitions(/W4 /wd4251)
 else()
+    add_definitions(-Wall -Wextra)
 endif()
 
 add_executable(${PROJECT_NAME} ${${PROJECT_NAME}_SOURCES})
 
-target_link_libraries(${PROJECT_NAME} hdf5 hdf5_cpp GTest GTestMain)
+target_link_libraries(${PROJECT_NAME} GTest GTestMain)
+target_link_libraries(${PROJECT_NAME} ${HDF5_EXPORT_LIBRARIES})
+
+add_test(NAME ${PROJECT_NAME} COMMAND ${PROJECT_NAME} WORKING_DIRECTORY ${CMAKE_BINARY_DIR})

--- a/unittests/gtest-helpers.hpp
+++ b/unittests/gtest-helpers.hpp
@@ -1,0 +1,60 @@
+#include <Eigen/Dense>
+#include <gtest/gtest.h>
+
+namespace Eigen {
+    // C++ and/or gtest require that these two methods, which are used by calling
+    // ASSERT_PRED_FORMAT2, be in the namespace of its argument. 
+
+    // utility function to print an eigen object to an ostream; gtest will use this when
+    // it outputs a matrix used in a failed assertion. Without this function, gtest seems
+    // to dump some kind of byte representation of an eigen matrix, which is not very
+    // helpful. 
+    template <class Derived>
+    void PrintTo(const Eigen::EigenBase<Derived>& mat, ::std::ostream* os)
+    {
+        (*os) << mat.derived() << "\n";
+    }
+
+    // utility function for gtest to use to check if two eigen objects are identical.
+    // returns assertion success when they are identical; returns assertion failure along
+    // with a nicely formatted message with the matrix contents when they are not
+    // identical.
+    // 
+    // I put this function in this matrix test cpp file for a few reasons: 1) there is
+    // not already a header file to put common test code for eigen3-hdf5, and 2) because
+    // I needed it to help me debug test failures as I implemented the no copy read and
+    // write functions. I really think that providing a header for common test code
+    // should be addressed at some point, and then this function (and its companion
+    // PrintTo) should be moved there.
+    // 
+    // Usage:
+    // 
+    // ASSERT_PRED_FORMAT2(assert_same, mat, mat2); 
+    template <class DerivedExp, class DerivedAct>
+    ::testing::AssertionResult assert_same(const char* exp_expr,
+        const char* act_expr,
+        const Eigen::EigenBase<DerivedExp>& exp,
+        const Eigen::EigenBase<DerivedAct>& act)
+    {
+        if (exp.rows() == act.rows() &&
+            exp.cols() == act.cols() &&
+            exp.derived() == act.derived())
+        {
+            return ::testing::AssertionSuccess();
+        }
+
+        // if eigen did not define the == operator, you could use
+        // exp.derived().cwiseEqual(act.derived()).all();
+
+        ::testing::AssertionResult result = ::testing::AssertionFailure()
+            << "Eigen objects are not the same: ("
+            << exp_expr << ", " << act_expr << ")\n"
+            << exp_expr << ":\n"
+            << ::testing::PrintToString(exp)
+            << "\n---and\n" << act_expr << ":\n"
+            << ::testing::PrintToString(act)
+            << "\n---are not equal!\n";
+
+        return result;
+    }
+} // namespace Eigen

--- a/unittests/test_Attribute.cpp
+++ b/unittests/test_Attribute.cpp
@@ -2,10 +2,26 @@
 #include <H5Cpp.h>
 
 #include "eigen3-hdf5.hpp"
-
-#include <gtest/gtest.h>
+#include "gtest-helpers.hpp"
 
 TEST(Attribute, Matrix) {
+    Eigen::Matrix<double, 2, 3, Eigen::RowMajor> rmat1, rmat2;
+    Eigen::Matrix<double, 2, 3, Eigen::ColMajor> cmat1, cmat2;
+    rmat1 << 1, 2, 3, 4, 5, 6;
+    cmat1 << 1, 2, 3, 4, 5, 6;
+    {
+        H5::H5File file("test_Attribute_Matrix.h5", H5F_ACC_TRUNC);
+        EigenHDF5::save_attribute(file, "rowmat", rmat1);
+        EigenHDF5::save_attribute(file, "colmat", cmat1);
+    }
+    {
+        H5::H5File file("test_Attribute_Matrix.h5", H5F_ACC_RDONLY);
+        EigenHDF5::load_attribute(file, "rowmat", rmat2);
+        EigenHDF5::load_attribute(file, "colmat", cmat2);
+    }
+    ASSERT_PRED_FORMAT2(assert_same, rmat1, rmat2);
+    ASSERT_PRED_FORMAT2(assert_same, cmat1, cmat2);
+    ASSERT_PRED_FORMAT2(assert_same, rmat2, cmat2);
 }
 
 TEST(Attribute, Integer) {
@@ -22,6 +38,6 @@ TEST(Attribute, String) {
     H5::H5File file("test_Attribute_String.h5", H5F_ACC_TRUNC);
     EigenHDF5::save_scalar_attribute(file, "str1", std::string("hello"));
     EigenHDF5::save_scalar_attribute(file, "str2", "goodbye");
-    char *s = "again";
+    const char *s = "again";
     EigenHDF5::save_scalar_attribute(file, "str3", s);
 }

--- a/unittests/test_MatrixRoundTrip.cpp
+++ b/unittests/test_MatrixRoundTrip.cpp
@@ -303,8 +303,3 @@ TEST(MatrixRoundTrip, DoubleFixedCol) {
     ASSERT_PRED_FORMAT2(assert_same, mat, fmat2);
     ASSERT_PRED_FORMAT2(assert_same, matblock, fmatblock2);
 }
-
-// To run all of the EigenHDF5 tests use:
-/*
--- --gtest_filter=Attribute*:Matrix*:Vector* --gtest_catch_exceptions=0 --gtest_break_on_failure=1
-*/

--- a/unittests/test_MatrixRoundTrip.cpp
+++ b/unittests/test_MatrixRoundTrip.cpp
@@ -5,66 +5,7 @@
 #include <H5Cpp.h>
 
 #include "eigen3-hdf5.hpp"
-
-#include <gtest/gtest.h>
-
-namespace Eigen {
-    // C++ and/or gtest require that these two methods, which are used by calling
-    // ASSERT_PRED_FORMAT2, be in the namespace of its argument. 
-
-    // utility function to print an eigen object to an ostream; gtest will use this when
-    // it outputs a matrix used in a failed assertion. Without this function, gtest seems
-    // to dump some kind of byte representation of an eigen matrix, which is not very
-    // helpful. 
-    template <class Derived>
-    void PrintTo(const Eigen::EigenBase<Derived>& mat, ::std::ostream* os)
-    {
-        (*os) << mat.derived() << "\n";
-    }
-
-    // utility function for gtest to use to check if two eigen objects are identical.
-    // returns assertion success when they are identical; returns assertion failure along
-    // with a nicely formatted message with the matrix contents when they are not
-    // identical.
-    // 
-    // I put this function in this matrix test cpp file for a few reasons: 1) there is
-    // not already a header file to put common test code for eigen3-hdf5, and 2) because
-    // I needed it to help me debug test failures as I implemented the no copy read and
-    // write functions. I really think that providing a header for common test code
-    // should be addressed at some point, and then this function (and its companion
-    // PrintTo) should be moved there.
-    // 
-    // Usage:
-    // 
-    // ASSERT_PRED_FORMAT2(assert_same, mat, mat2); 
-    template <class DerivedExp, class DerivedAct>
-    ::testing::AssertionResult assert_same(const char* exp_expr,
-        const char* act_expr,
-        const Eigen::EigenBase<DerivedExp>& exp,
-        const Eigen::EigenBase<DerivedAct>& act)
-    {
-        if (exp.rows() == act.rows() &&
-            exp.cols() == act.cols() &&
-            exp.derived() == act.derived())
-        {
-            return ::testing::AssertionSuccess();
-        }
-
-        // if eigen did not define the == operator, you could use
-        // exp.derived().cwiseEqual(act.derived()).all();
-
-        ::testing::AssertionResult result = ::testing::AssertionFailure()
-            << "Eigen objects are not the same: ("
-            << exp_expr << ", " << act_expr << ")\n"
-            << exp_expr << ":\n"
-            << ::testing::PrintToString(exp)
-            << "\n---and\n" << act_expr << ":\n"
-            << ::testing::PrintToString(act)
-            << "\n---are not equal!\n";
-
-        return result;
-    }
-} // namespace Eigen
+#include "gtest-helpers.hpp"
 
 TEST(MatrixRoundTrip, Double) {
     Eigen::MatrixXd mat(3, 4), mat2;
@@ -259,18 +200,11 @@ TEST(MatrixRoundTrip, DoubleFixedRow) {
     }
     {
         H5::H5File file("test_MatrixRoundTrip_DoubleFixedRow.h5", H5F_ACC_RDONLY);
-#if 0
-        // this won't compile because load has a transposeInPlace, which is not allowed for
-        // fixed size matrices. 
-        EigenHDF5::load(file, "double_matrix", fmat2);
-        EigenHDF5::load(file, "matrix_block", fmatblock2);
-#else
         // read into a dynamic sized matrix and then copy into fixed size
         EigenHDF5::load(file, "double_matrix", dmat2);
         EigenHDF5::load(file, "matrix_block", dmatblock2);
         fmat2 = dmat2;
         fmatblock2 = dmatblock2;
-#endif
     }
     ASSERT_PRED_FORMAT2(assert_same, mat, fmat2);
     ASSERT_PRED_FORMAT2(assert_same, matblock, fmatblock2);
@@ -295,8 +229,6 @@ TEST(MatrixRoundTrip, DoubleFixedCol) {
     }
     {
         H5::H5File file("test_MatrixRoundTrip_DoubleFixedRow.h5", H5F_ACC_RDONLY);
-        // this won't compile because load has a transposeInPlace, which is not allowed for
-        // fixed size matrices. 
         EigenHDF5::load(file, "double_matrix", fmat2);
         EigenHDF5::load(file, "matrix_block", fmatblock2);
     }


### PR DESCRIPTION
This pull request contains the following:
* adds test for save/load eigen matrix as an attribute
* fixes the compilation error with read_colmat and fixes a bug in its implementation, which is why I added the attribute test.
* eliminates the compiler warnings on gcc (and all but one, in std::vector, with VS 2013)
* adds CMakeLists.txt files for building unit tests with cmake