### PR TITLE
clean up new code

### DIFF
--- a/eigen3-hdf5.hpp
+++ b/eigen3-hdf5.hpp
@@ -231,21 +231,18 @@ namespace internal
             return false;
         }
 
-        typename Derived::Index irows = mat.rows();
-        typename Derived::Index icols = mat.cols();
-        typename Derived::Index imat_stride = mat.derived().outerStride();
-        assert(irows >= 0);
-        assert(icols >= 0);
-        assert(imat_stride >= 0);
-        hsize_t rows = irows >= 0 ? irows : 0;
-        hsize_t cols = icols >= 0 ? icols : 0;
-        hsize_t mat_stride = imat_stride >= 0 ? imat_stride : 0;
+        assert(mat.rows() >= 0);
+        assert(mat.cols() >= 0);
+        assert(mat.derived().outerStride() >= 0);
+        hsize_t rows = hsize_t(mat.rows());
+        hsize_t cols = hsize_t(mat.cols());
+        hsize_t stride = hsize_t(mat.derived().outerStride());
 
         // slab params for the file data
         hsize_t fstride[2] = { 1, cols };
 
         // slab params for the memory data
-        hsize_t mstride[2] = { 1, mat_stride };
+        hsize_t mstride[2] = { 1, stride };
 
         // slab params for both file and memory data
         hsize_t count[2] = { 1, 1 };
@@ -253,7 +250,7 @@ namespace internal
         hsize_t start[2] = { 0, 0 };
 
         // memory dataspace
-        hsize_t mdim[2] = { rows, mat_stride };
+        hsize_t mdim[2] = { rows, stride };
         H5::DataSpace mspace(2, mdim);
 
         dspace->selectHyperslab(H5S_SELECT_SET, count, start, fstride, block);
@@ -277,16 +274,13 @@ namespace internal
             return false;
         }
 
-        typename Derived::Index irows = mat.rows();
-        typename Derived::Index icols = mat.cols();
-        typename Derived::Index istride = mat.derived().outerStride();
-        assert(irows >= 0);
-        assert(icols >= 0);
-        assert(istride >= 0);
-        hsize_t rows = irows >= 0 ? irows : 0;
-        hsize_t cols = icols >= 0 ? icols : 0;
-        hsize_t stride = istride >= 0 ? istride : 0;
-
+        assert(mat.rows() >= 0);
+        assert(mat.cols() >= 0);
+        assert(mat.derived().outerStride() >= 0);
+        hsize_t rows = hsize_t(mat.rows());
+        hsize_t cols = hsize_t(mat.cols());
+        hsize_t stride = hsize_t(mat.derived().outerStride());
+        
         // slab params for the file data
         hsize_t fstride[2] = { 1, cols };
         hsize_t fcount[2] = { 1, 1 };
@@ -417,22 +411,19 @@ namespace internal
             return false;
         }
 
-        typename Derived::Index irows = mat.rows();
-        typename Derived::Index icols = mat.cols();
-        typename Derived::Index istride = mat.derived().outerStride();
-        if (istride != irows)
+        assert(mat.rows() >= 0);
+        assert(mat.cols() >= 0);
+        assert(mat.derived().outerStride() >= 0);
+        hsize_t rows = hsize_t(mat.rows());
+        hsize_t cols = hsize_t(mat.cols());
+        hsize_t stride = hsize_t(mat.derived().outerStride());
+
+        if (stride != rows)
         {
             // this function does not (yet) read into a mat that has a different stride than the
             // dataset. 
             return false;
         }
-        assert(irows >= 0);
-        assert(icols >= 0);
-        assert(istride >= 0);
-        hsize_t rows = irows >= 0 ? irows : 0;
-        hsize_t cols = icols >= 0 ? icols : 0;
-        hsize_t stride = istride >= 0 ? istride : 0;
-
 
         // slab params for the file data
         hsize_t fstride[2] = { 1, cols };

--- a/eigen3-hdf5.hpp
+++ b/eigen3-hdf5.hpp
@@ -271,7 +271,6 @@ namespace internal
             return false;
         }
 
-        bool written = false;
         typename Derived::Index rows = mat.rows();
         typename Derived::Index cols = mat.cols();
         typename Derived::Index stride = mat.derived().outerStride();
@@ -451,10 +450,13 @@ namespace internal
         Eigen::DenseBase<Derived> &mat_ = const_cast<Eigen::DenseBase<Derived> &>(mat);
         mat_.derived().resize(rows, cols);
         bool written = false;
-        if (mat.Flags & Eigen::RowMajor || dimensions[0] == 1 || dimensions[1] == 1)
+        bool isRowMajor = mat.Flags & Eigen::RowMajor;
+        if (isRowMajor || dimensions[0] == 1 || dimensions[1] == 1)
         {
             // mat is already row major
-            typename Derived::Index stride = mat_.derived().outerStride();
+            typename Derived::Index istride = mat_.derived().outerStride();
+            assert(istride >= 0);
+            hsize_t stride = istride >= 0 ? istride : 0;
             if (stride == cols || (stride == rows && cols == 1))
             {
                 // mat has natural stride, so read directly into its data block

--- a/eigen3-hdf5.hpp
+++ b/eigen3-hdf5.hpp
@@ -231,9 +231,15 @@ namespace internal
             return false;
         }
 
-        typename Derived::Index rows = mat.rows();
-        typename Derived::Index cols = mat.cols();
-        typename Derived::Index mat_stride = mat.derived().outerStride();
+        typename Derived::Index irows = mat.rows();
+        typename Derived::Index icols = mat.cols();
+        typename Derived::Index imat_stride = mat.derived().outerStride();
+        assert(irows >= 0);
+        assert(icols >= 0);
+        assert(imat_stride >= 0);
+        hsize_t rows = irows >= 0 ? irows : 0;
+        hsize_t cols = icols >= 0 ? icols : 0;
+        hsize_t mat_stride = imat_stride >= 0 ? imat_stride : 0;
 
         // slab params for the file data
         hsize_t fstride[2] = { 1, cols };
@@ -271,9 +277,15 @@ namespace internal
             return false;
         }
 
-        typename Derived::Index rows = mat.rows();
-        typename Derived::Index cols = mat.cols();
-        typename Derived::Index stride = mat.derived().outerStride();
+        typename Derived::Index irows = mat.rows();
+        typename Derived::Index icols = mat.cols();
+        typename Derived::Index istride = mat.derived().outerStride();
+        assert(irows >= 0);
+        assert(icols >= 0);
+        assert(istride >= 0);
+        hsize_t rows = irows >= 0 ? irows : 0;
+        hsize_t cols = icols >= 0 ? icols : 0;
+        hsize_t stride = istride >= 0 ? istride : 0;
 
         // slab params for the file data
         hsize_t fstride[2] = { 1, cols };
@@ -291,7 +303,7 @@ namespace internal
 
         // transpose the column major data in memory to the row major data in the file by
         // writing one row slab at a time. 
-        for (int i = 0; i < rows; i++)
+        for (hsize_t i = 0; i < rows; i++)
         {
             hsize_t fstart[2] = { i, 0 };
             hsize_t mstart[2] = { 0, i };
@@ -376,12 +388,28 @@ namespace internal
         dataset.read(datatype, data);
     }
     
+    // read a column major attribute; I do not know if there is an hdf routine to read an
+    // attribute hyperslab, so I take the lazy way out: just read the conventional hdf
+    // row major data and let eigen copy it into mat. 
     template <typename Derived>
-    bool read_colmat(Eigen::EigenBase<Derived>* mat,
+    bool read_colmat(const Eigen::DenseBase<Derived> &mat,
+        const H5::DataType * const datatype,
+        const H5::Attribute &dataset)
+    {
+        typename Derived::Index rows = mat.rows();
+        typename Derived::Index cols = mat.cols();
+        typename Eigen::Matrix<typename Derived::Scalar, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor> temp(rows, cols);
+        internal::read_data(dataset, temp.data(), *datatype);
+        const_cast<Eigen::DenseBase<Derived> &>(mat) = temp;
+        return true;
+    }
+
+    template <typename Derived>
+    bool read_colmat(const Eigen::DenseBase<Derived> &mat,
         const H5::DataType * const datatype,
         const H5::DataSet &dataset)
     {
-        if (mat->derived().innerStride() != 1)
+        if (mat.derived().innerStride() != 1)
         {
             // inner stride != 1 is an edge case this function does not (yet) handle. (I think it
             // could by using the inner stride as the first element of mstride below. But I do
@@ -389,15 +417,21 @@ namespace internal
             return false;
         }
 
-        typename Derived::Index rows = mat->rows();
-        typename Derived::Index cols = mat->cols();
-        typename Derived::Index stride = mat->derived().outerStride();
-        if (stride != rows)
+        typename Derived::Index irows = mat.rows();
+        typename Derived::Index icols = mat.cols();
+        typename Derived::Index istride = mat.derived().outerStride();
+        if (istride != irows)
         {
             // this function does not (yet) read into a mat that has a different stride than the
             // dataset. 
             return false;
         }
+        assert(irows >= 0);
+        assert(icols >= 0);
+        assert(istride >= 0);
+        hsize_t rows = irows >= 0 ? irows : 0;
+        hsize_t cols = icols >= 0 ? icols : 0;
+        hsize_t stride = istride >= 0 ? istride : 0;
 
 
         // slab params for the file data
@@ -420,13 +454,13 @@ namespace internal
 
         // transpose the column major data in memory to the row major data in the file by
         // writing one row slab at a time. 
-        for (int i = 0; i < rows; i++)
+        for (hsize_t i = 0; i < rows; i++)
         {
             hsize_t fstart[2] = { i, 0 };
             hsize_t mstart[2] = { 0, i };
             fspace.selectHyperslab(H5S_SELECT_SET, fcount, fstart, fstride, fblock);
             mspace.selectHyperslab(H5S_SELECT_SET, mcount, mstart, mstride, mblock);
-            dataset.read(mat->derived().data(), *datatype, mspace, fspace);
+            dataset.read(const_cast<Eigen::DenseBase<Derived> &>(mat).derived().data(), *datatype, mspace, fspace);
         }
         return true;
     }
@@ -469,7 +503,7 @@ namespace internal
             // colmajor flag is 0 so the assert needs to check that mat is not rowmajor. 
             assert(!(mat.Flags & Eigen::RowMajor));
 
-            //written = read_colmat(&mat_, datatype, dataset);
+            written = read_colmat(mat_, datatype, dataset);
         }
 
         if (!written)

--- a/unittests/gtest-helpers.hpp
+++ b/unittests/gtest-helpers.hpp
@@ -1,0 +1,60 @@
+#include <Eigen/Dense>
+#include <gtest/gtest.h>
+
+namespace Eigen {
+    // C++ and/or gtest require that these two methods, which are used by calling
+    // ASSERT_PRED_FORMAT2, be in the namespace of its argument. 
+
+    // utility function to print an eigen object to an ostream; gtest will use this when
+    // it outputs a matrix used in a failed assertion. Without this function, gtest seems
+    // to dump some kind of byte representation of an eigen matrix, which is not very
+    // helpful. 
+    template <class Derived>
+    void PrintTo(const Eigen::EigenBase<Derived>& mat, ::std::ostream* os)
+    {
+        (*os) << mat.derived() << "\n";
+    }
+
+    // utility function for gtest to use to check if two eigen objects are identical.
+    // returns assertion success when they are identical; returns assertion failure along
+    // with a nicely formatted message with the matrix contents when they are not
+    // identical.
+    // 
+    // I put this function in this matrix test cpp file for a few reasons: 1) there is
+    // not already a header file to put common test code for eigen3-hdf5, and 2) because
+    // I needed it to help me debug test failures as I implemented the no copy read and
+    // write functions. I really think that providing a header for common test code
+    // should be addressed at some point, and then this function (and its companion
+    // PrintTo) should be moved there.
+    // 
+    // Usage:
+    // 
+    // ASSERT_PRED_FORMAT2(assert_same, mat, mat2); 
+    template <class DerivedExp, class DerivedAct>
+    ::testing::AssertionResult assert_same(const char* exp_expr,
+        const char* act_expr,
+        const Eigen::EigenBase<DerivedExp>& exp,
+        const Eigen::EigenBase<DerivedAct>& act)
+    {
+        if (exp.rows() == act.rows() &&
+            exp.cols() == act.cols() &&
+            exp.derived() == act.derived())
+        {
+            return ::testing::AssertionSuccess();
+        }
+
+        // if eigen did not define the == operator, you could use
+        // exp.derived().cwiseEqual(act.derived()).all();
+
+        ::testing::AssertionResult result = ::testing::AssertionFailure()
+            << "Eigen objects are not the same: ("
+            << exp_expr << ", " << act_expr << ")\n"
+            << exp_expr << ":\n"
+            << ::testing::PrintToString(exp)
+            << "\n---and\n" << act_expr << ":\n"
+            << ::testing::PrintToString(act)
+            << "\n---are not equal!\n";
+
+        return result;
+    }
+} // namespace Eigen

--- a/unittests/test_Attribute.cpp
+++ b/unittests/test_Attribute.cpp
@@ -2,10 +2,26 @@
 #include <H5Cpp.h>
 
 #include "eigen3-hdf5.hpp"
-
-#include <gtest/gtest.h>
+#include "gtest-helpers.hpp"
 
 TEST(Attribute, Matrix) {
+    Eigen::Matrix<double, 2, 3, Eigen::RowMajor> rmat1, rmat2;
+    Eigen::Matrix<double, 2, 3, Eigen::ColMajor> cmat1, cmat2;
+    rmat1 << 1, 2, 3, 4, 5, 6;
+    cmat1 << 1, 2, 3, 4, 5, 6;
+    {
+        H5::H5File file("test_Attribute_Matrix.h5", H5F_ACC_TRUNC);
+        EigenHDF5::save_attribute(file, "rowmat", rmat1);
+        EigenHDF5::save_attribute(file, "colmat", cmat1);
+    }
+    {
+        H5::H5File file("test_Attribute_Matrix.h5", H5F_ACC_RDONLY);
+        EigenHDF5::load_attribute(file, "rowmat", rmat2);
+        EigenHDF5::load_attribute(file, "colmat", cmat2);
+    }
+    ASSERT_PRED_FORMAT2(assert_same, rmat1, rmat2);
+    ASSERT_PRED_FORMAT2(assert_same, cmat1, cmat2);
+    ASSERT_PRED_FORMAT2(assert_same, rmat2, cmat2);
 }
 
 TEST(Attribute, Integer) {
@@ -22,6 +38,6 @@ TEST(Attribute, String) {
     H5::H5File file("test_Attribute_String.h5", H5F_ACC_TRUNC);
     EigenHDF5::save_scalar_attribute(file, "str1", std::string("hello"));
     EigenHDF5::save_scalar_attribute(file, "str2", "goodbye");
-    char *s = "again";
+    const char *s = "again";
     EigenHDF5::save_scalar_attribute(file, "str3", s);
 }

--- a/unittests/test_MatrixRoundTrip.cpp
+++ b/unittests/test_MatrixRoundTrip.cpp
@@ -303,8 +303,3 @@ TEST(MatrixRoundTrip, DoubleFixedCol) {
     ASSERT_PRED_FORMAT2(assert_same, mat, fmat2);
     ASSERT_PRED_FORMAT2(assert_same, matblock, fmatblock2);
 }
-
-// To run all of the EigenHDF5 tests use:
-/*
--- --gtest_filter=Attribute*:Matrix*:Vector* --gtest_catch_exceptions=0 --gtest_break_on_failure=1
-*/

--- a/unittests/test_MatrixRoundTrip.cpp
+++ b/unittests/test_MatrixRoundTrip.cpp
@@ -5,66 +5,7 @@
 #include <H5Cpp.h>
 
 #include "eigen3-hdf5.hpp"
-
-#include <gtest/gtest.h>
-
-namespace Eigen {
-    // C++ and/or gtest require that these two methods, which are used by calling
-    // ASSERT_PRED_FORMAT2, be in the namespace of its argument. 
-
-    // utility function to print an eigen object to an ostream; gtest will use this when
-    // it outputs a matrix used in a failed assertion. Without this function, gtest seems
-    // to dump some kind of byte representation of an eigen matrix, which is not very
-    // helpful. 
-    template <class Derived>
-    void PrintTo(const Eigen::EigenBase<Derived>& mat, ::std::ostream* os)
-    {
-        (*os) << mat.derived() << "\n";
-    }
-
-    // utility function for gtest to use to check if two eigen objects are identical.
-    // returns assertion success when they are identical; returns assertion failure along
-    // with a nicely formatted message with the matrix contents when they are not
-    // identical.
-    // 
-    // I put this function in this matrix test cpp file for a few reasons: 1) there is
-    // not already a header file to put common test code for eigen3-hdf5, and 2) because
-    // I needed it to help me debug test failures as I implemented the no copy read and
-    // write functions. I really think that providing a header for common test code
-    // should be addressed at some point, and then this function (and its companion
-    // PrintTo) should be moved there.
-    // 
-    // Usage:
-    // 
-    // ASSERT_PRED_FORMAT2(assert_same, mat, mat2); 
-    template <class DerivedExp, class DerivedAct>
-    ::testing::AssertionResult assert_same(const char* exp_expr,
-        const char* act_expr,
-        const Eigen::EigenBase<DerivedExp>& exp,
-        const Eigen::EigenBase<DerivedAct>& act)
-    {
-        if (exp.rows() == act.rows() &&
-            exp.cols() == act.cols() &&
-            exp.derived() == act.derived())
-        {
-            return ::testing::AssertionSuccess();
-        }
-
-        // if eigen did not define the == operator, you could use
-        // exp.derived().cwiseEqual(act.derived()).all();
-
-        ::testing::AssertionResult result = ::testing::AssertionFailure()
-            << "Eigen objects are not the same: ("
-            << exp_expr << ", " << act_expr << ")\n"
-            << exp_expr << ":\n"
-            << ::testing::PrintToString(exp)
-            << "\n---and\n" << act_expr << ":\n"
-            << ::testing::PrintToString(act)
-            << "\n---are not equal!\n";
-
-        return result;
-    }
-} // namespace Eigen
+#include "gtest-helpers.hpp"
 
 TEST(MatrixRoundTrip, Double) {
     Eigen::MatrixXd mat(3, 4), mat2;
@@ -259,18 +200,11 @@ TEST(MatrixRoundTrip, DoubleFixedRow) {
     }
     {
         H5::H5File file("test_MatrixRoundTrip_DoubleFixedRow.h5", H5F_ACC_RDONLY);
-#if 0
-        // this won't compile because load has a transposeInPlace, which is not allowed for
-        // fixed size matrices. 
-        EigenHDF5::load(file, "double_matrix", fmat2);
-        EigenHDF5::load(file, "matrix_block", fmatblock2);
-#else
         // read into a dynamic sized matrix and then copy into fixed size
         EigenHDF5::load(file, "double_matrix", dmat2);
         EigenHDF5::load(file, "matrix_block", dmatblock2);
         fmat2 = dmat2;
         fmatblock2 = dmatblock2;
-#endif
     }
     ASSERT_PRED_FORMAT2(assert_same, mat, fmat2);
     ASSERT_PRED_FORMAT2(assert_same, matblock, fmatblock2);
@@ -295,8 +229,6 @@ TEST(MatrixRoundTrip, DoubleFixedCol) {
     }
     {
         H5::H5File file("test_MatrixRoundTrip_DoubleFixedRow.h5", H5F_ACC_RDONLY);
-        // this won't compile because load has a transposeInPlace, which is not allowed for
-        // fixed size matrices. 
         EigenHDF5::load(file, "double_matrix", fmat2);
         EigenHDF5::load(file, "matrix_block", fmatblock2);
     }


### PR DESCRIPTION
remove comment specific to my test setup
turn up msvc warnings

use /W4 and eliminate all (but one) warnings
clean up code

fix the compile error using read_colmat.

Fix gcc compiler warnings.
extend tests to save/load for attribute matrix

Add test to test_Attribute.cpp to exercise loading and saving of an
eigen matrix as an attribute.

This changed forced refactoring the test helper code that was buried in
test_MatrixRoundTrip.cpp to be moved to a header, gtest-helpers.cpp, so
attributes may be tested the same as datasets.